### PR TITLE
それぞれ選択した県の人口構成データを取得/取得したデータをリストに格納する処理/もう一度押すと削除する処理/ブラウザに表示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,9 @@
-import React from 'react';
-import { usePopulationDataQuery } from './components/Hooks/usePopulationDataQuery';
-import { usePrefDataQuery } from './components/Hooks/usePrefDataQuery';
-import { Layout } from './components/Layout/Layout';
-import { SectionTitle } from './components/Text/SectionTitle';
-import { Title } from './components/Text/Title';
+import { PrefPopulationChart } from './Pages/PrefPopulationChart';
 
 function App() {
-  const { prefData } = usePrefDataQuery();
-  const { populationData } = usePopulationDataQuery();
   return (
     <>
-      <Layout>
-        <Title>都道府県別の総人口推移</Title>
-
-        <div className='border m-6 p-4 rounded-md shadow'>
-          <SectionTitle>都道府県</SectionTitle>
-          <div className='w-full flex  flex-wrap p-8 gap-3'>
-            {prefData?.result.map((pref) => {
-              return (
-                <div key={pref.prefCode} className='flex gap-1'>
-                  <input type='checkbox' />
-                  <p>{pref.prefName}</p>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </Layout>
+      <PrefPopulationChart />
     </>
   );
 }

--- a/src/Pages/PrefPopulationChart.tsx
+++ b/src/Pages/PrefPopulationChart.tsx
@@ -7,8 +7,8 @@ import { Layout } from '../components/Layout/Layout';
 import { SectionTitle } from '../components/Text/SectionTitle';
 import { Title } from '../components/Text/Title';
 
-// prefNum
-export type PrefNum = {
+// 選択した県の番号と名前を格納する型
+export type SelectedPref = {
   prefCode: string | undefined;
   prefName: string | undefined;
 };
@@ -36,14 +36,14 @@ export type PopulationYearValue = {
 export const PrefPopulationChart = () => {
   const { prefData } = usePrefDataQuery();
   const { populationData, getPopulationData } = usePopulationDataQuery();
-  const [prefNum, setPrefNum] = useState<PrefNum[]>([]);
+  const [selectedPref, setSelectedPref] = useState<SelectedPref[]>([]);
   const [prefList, setPrefList] = useState<PopulationData[]>([]);
 
   const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const prefValue = prefData?.result?.find((pref) => pref.prefCode == e.target.value);
-    if (prefNum.find((pref) => pref.prefCode === prefValue?.prefCode)) {
-      setPrefNum(
-        prefNum.filter((pref) => {
+    if (selectedPref.find((pref) => pref.prefCode === prefValue?.prefCode)) {
+      setSelectedPref(
+        selectedPref.filter((pref) => {
           return pref.prefCode !== prefValue?.prefCode;
         })
       );
@@ -53,7 +53,7 @@ export const PrefPopulationChart = () => {
         })
       );
     } else {
-      setPrefNum((prev) => [...prev, { prefCode: prefValue?.prefCode, prefName: prefValue?.prefName }]);
+      setSelectedPref((prev) => [...prev, { prefCode: prefValue?.prefCode, prefName: prefValue?.prefName }]);
       await getPopulationData({ prefCode: prefValue?.prefCode, prefName: prefValue?.prefName });
     }
   };
@@ -68,6 +68,7 @@ export const PrefPopulationChart = () => {
     if (!prefList.find((pref) => pref.prefCode === populationData.prefCode)) {
       setPrefList((prev) => [...prev, populationData]);
     }
+    console.log(prefList);
   }, [populationData]);
 
   return (
@@ -90,7 +91,7 @@ export const PrefPopulationChart = () => {
       <div>
         <div className='text-center my-2'>選択</div>
         <div className='flex flex-wrap gap-3 p-4'>
-          {prefNum.map((pref: PrefNum) => {
+          {selectedPref.map((pref: SelectedPref) => {
             return <div key={pref.prefCode}>{pref.prefCode}</div>;
           })}
         </div>

--- a/src/Pages/PrefPopulationChart.tsx
+++ b/src/Pages/PrefPopulationChart.tsx
@@ -65,7 +65,7 @@ export const PrefPopulationChart = () => {
           {prefData?.result?.map((pref) => {
             return (
               <div key={pref.prefCode} className='flex gap-1'>
-                <input type='checkbox' value={pref.prefCode} onChange={handleChange} />
+                <input type='checkbox' value={pref.prefCode} onChange={handleChange} className='focus:outline-none' />
                 <p>{pref.prefName}</p>
               </div>
             );

--- a/src/Pages/PrefPopulationChart.tsx
+++ b/src/Pages/PrefPopulationChart.tsx
@@ -1,0 +1,125 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import React, { useEffect, useState } from 'react';
+import { usePopulationDataQuery } from '../components/Hooks/usePopulationDataQuery';
+import { usePrefDataQuery } from '../components/Hooks/usePrefDataQuery';
+import { Layout } from '../components/Layout/Layout';
+import { SectionTitle } from '../components/Text/SectionTitle';
+import { Title } from '../components/Text/Title';
+
+// prefNum
+export type PrefNum = {
+  prefCode: string | undefined;
+  prefName: string | undefined;
+};
+//人口構成(PopulationData）の型定義
+export type PopulationData = {
+  prefCode: string | undefined;
+  prefName: string | undefined;
+  boundaryYear: string;
+  data: {
+    data: {
+      year: number | null;
+      value: number | null;
+    }[];
+    label: string;
+  };
+  label: string;
+};
+
+//それぞれの県のyearとvalueの型定義
+export type PopulationYearValue = {
+  year: number | null;
+  value: number | null;
+};
+
+export const PrefPopulationChart = () => {
+  const { prefData } = usePrefDataQuery();
+  const { populationData, getPopulationData } = usePopulationDataQuery();
+  const [prefNum, setPrefNum] = useState<PrefNum[]>([]);
+  const [prefList, setPrefList] = useState<PopulationData[]>([]);
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const prefValue = prefData?.result?.find((pref) => pref.prefCode == e.target.value);
+    if (prefNum.find((pref) => pref.prefCode === prefValue?.prefCode)) {
+      setPrefNum(
+        prefNum.filter((pref) => {
+          return pref.prefCode !== prefValue?.prefCode;
+        })
+      );
+      setPrefList(
+        prefList.filter((pref) => {
+          return pref.prefCode !== prefValue?.prefCode && pref.prefCode !== '';
+        })
+      );
+    } else {
+      setPrefNum((prev) => [...prev, { prefCode: prefValue?.prefCode, prefName: prefValue?.prefName }]);
+      await getPopulationData({ prefCode: prefValue?.prefCode, prefName: prefValue?.prefName });
+    }
+  };
+
+  useEffect(() => {
+    setPrefList(
+      prefList.filter((pref) => {
+        return pref.prefCode !== '';
+      })
+    );
+    //prefListにないpopulationDataであれば追加
+    if (!prefList.find((pref) => pref.prefCode === populationData.prefCode)) {
+      setPrefList((prev) => [...prev, populationData]);
+    }
+  }, [populationData]);
+
+  return (
+    <Layout>
+      <Title>都道府県別の総人口推移</Title>
+
+      <div className='border m-6 p-4 rounded-md shadow'>
+        <SectionTitle>都道府県</SectionTitle>
+        <div className='w-full flex  flex-wrap p-8 gap-3'>
+          {prefData?.result?.map((pref) => {
+            return (
+              <div key={pref.prefCode} className='flex gap-1'>
+                <input type='checkbox' value={pref.prefCode} onChange={handleChange} />
+                <p>{pref.prefName}</p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div>
+        <div className='text-center my-2'>選択</div>
+        <div className='flex flex-wrap gap-3 p-4'>
+          {prefNum.map((pref: PrefNum) => {
+            return <div key={pref.prefCode}>{pref.prefCode}</div>;
+          })}
+        </div>
+      </div>
+
+      <div>
+        <div className='text-center my-2'>人口構成</div>
+        <div className='flex justify-center flex-wrap gap-2 p-2'>
+          {prefList?.map((pref: PopulationData, i: number) => {
+            return (
+              <div key={`${i}-${i}`}>
+                <div className='text-green-500'>{pref.prefCode}</div>
+                <div className='text-gray-600'>{pref.prefName}</div>
+                <div className='text-purple-500'>{pref.boundaryYear}</div>
+                {pref.data?.data?.map((prefChild: PopulationYearValue, index: number) => {
+                  return (
+                    <div key={`${i}-${index}`}>
+                      <div className='flex gap-2 mr-2'>
+                        <div className='text-red-500'>{prefChild.year}</div>
+                        <div className='text-blue-500'>{prefChild.value}</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Layout>
+  );
+};

--- a/src/components/Hooks/usePopulationDataQuery.tsx
+++ b/src/components/Hooks/usePopulationDataQuery.tsx
@@ -1,24 +1,43 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
+import { PopulationData, PrefNum } from '../../Pages/PrefPopulationChart';
 
 export const usePopulationDataQuery = () => {
-  const [populationData, setPopulationData] = useState<{ prefName: string; data: { year: number; value: number }[] }[]>(
-    []
-  );
-  useEffect(() => {
-    axios
-      .get(`https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?&prefCode=${1}`, {
-        headers: { 'X-API-KEY': process.env.REACT_APP_API_KEY },
-      })
-      .then((response) => {
-        console.log(response.data);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        setPopulationData(response.data);
-      })
-      .catch((error) => {
-        alert(error);
-      });
+  const [populationData, setPopulationData] = useState<PopulationData>({
+    prefCode: '',
+    prefName: '',
+    boundaryYear: '',
+    data: { data: [{ year: null, value: null }], label: '' },
+    label: '',
+  });
+
+  const getPopulationData = useCallback(async ({ prefCode, prefName }: PrefNum) => {
+    console.log(prefCode, prefName);
+
+    if (prefCode) {
+      await axios
+        .get(`https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?&prefCode=${prefCode}`, {
+          headers: {
+            'X-API-KEY': process.env.REACT_APP_API_KEY,
+          },
+        })
+        .then((response) => {
+          setPopulationData((prev: PopulationData) => ({
+            ...prev,
+            prefCode: prefCode,
+            prefName: prefName,
+            boundaryYear: response.data.result.boundaryYear,
+            data: response.data.result.data[0],
+            label: response.data.result.data[0].label,
+          }));
+        })
+        .catch((error) => {
+          alert(error);
+        });
+    }
   }, []);
 
-  return { populationData };
+  return { populationData, getPopulationData };
 };

--- a/src/components/Hooks/usePopulationDataQuery.tsx
+++ b/src/components/Hooks/usePopulationDataQuery.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import axios from 'axios';
 import { useCallback, useState } from 'react';
-import { PopulationData, PrefNum } from '../../Pages/PrefPopulationChart';
+import { PopulationData, SelectedPref } from '../../Pages/PrefPopulationChart';
 
 export const usePopulationDataQuery = () => {
   const [populationData, setPopulationData] = useState<PopulationData>({
@@ -13,9 +13,7 @@ export const usePopulationDataQuery = () => {
     label: '',
   });
 
-  const getPopulationData = useCallback(async ({ prefCode, prefName }: PrefNum) => {
-    console.log(prefCode, prefName);
-
+  const getPopulationData = useCallback(async ({ prefCode, prefName }: SelectedPref) => {
     if (prefCode) {
       await axios
         .get(`https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?&prefCode=${prefCode}`, {

--- a/src/components/Hooks/usePopulationDataQuery.tsx
+++ b/src/components/Hooks/usePopulationDataQuery.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import axios from 'axios';
@@ -8,9 +9,8 @@ export const usePopulationDataQuery = () => {
   const [populationData, setPopulationData] = useState<PopulationData>({
     prefCode: '',
     prefName: '',
-    boundaryYear: '',
-    data: { data: [{ year: null, value: null }], label: '' },
-    label: '',
+    yearData: [],
+    valueData: [],
   });
 
   const getPopulationData = useCallback(async ({ prefCode, prefName }: SelectedPref) => {
@@ -22,13 +22,18 @@ export const usePopulationDataQuery = () => {
           },
         })
         .then((response) => {
+          //グラフで扱えるようにデータを整形
+          //yearを取得。グラフのx軸に使用
+          const yearData = response.data.result.data[0].data.map((data: { year: number }) => data.year);
+          //valueを取得。グラフのy軸に使用
+          const valueData = response.data.result.data[0].data.map((data: { value: number }) => data.value);
+
           setPopulationData((prev: PopulationData) => ({
             ...prev,
             prefCode: prefCode,
             prefName: prefName,
-            boundaryYear: response.data.result.boundaryYear,
-            data: response.data.result.data[0],
-            label: response.data.result.data[0].label,
+            yearData: yearData,
+            valueData: valueData,
           }));
         })
         .catch((error) => {

--- a/src/components/Hooks/usePrefDataQuery.tsx
+++ b/src/components/Hooks/usePrefDataQuery.tsx
@@ -5,7 +5,7 @@ export const usePrefDataQuery = () => {
   const [prefData, setPrefData] = useState<{
     message: null;
     result: {
-      prefCode: number;
+      prefCode: string;
       prefName: string;
     }[];
   } | null>(null);

--- a/src/components/Hooks/usePrefDataQuery.tsx
+++ b/src/components/Hooks/usePrefDataQuery.tsx
@@ -8,7 +8,7 @@ export const usePrefDataQuery = () => {
       prefCode: string;
       prefName: string;
     }[];
-  } | null>(null);
+  }>();
 
   useEffect(() => {
     axios

--- a/src/components/Hooks/usePrefDataQuery.tsx
+++ b/src/components/Hooks/usePrefDataQuery.tsx
@@ -16,7 +16,6 @@ export const usePrefDataQuery = () => {
         headers: { 'X-API-KEY': process.env.REACT_APP_API_KEY },
       })
       .then((response) => {
-        console.log(response.data);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         setPrefData(response.data);
       })

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -6,6 +6,6 @@ type LayoutProps = {
 
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
-    <div className='flex flex-col justify-center items-center min-w-full gap-8  m-0  bg-white  grow'>{children}</div>
+    <div className='flex flex-col justify-center items-center min-w-full gap-8  m-0 pb-10 bg-white  grow'>{children}</div>
   );
 };

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -6,6 +6,8 @@ type LayoutProps = {
 
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
-    <div className='flex flex-col justify-center items-center min-w-full gap-8  m-0 pb-10 bg-white  grow'>{children}</div>
+    <div className='flex flex-col justify-center items-center min-w-full gap-8  m-0 pb-10 bg-white  grow'>
+      {children}
+    </div>
   );
 };

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const Loading = () => {
+  return (
+    <div>Loading...</div>
+  )
+}

--- a/src/components/Text/Title.tsx
+++ b/src/components/Text/Title.tsx
@@ -5,5 +5,5 @@ type TitleProps = {
 };
 
 export const Title: React.FC<TitleProps> = ({ children }) => {
-  return <div className='text-4xl font-bold text-center bg-zinc-300	py-4 w-full'>{children}</div>;
+  return <div className='sm:text-4xl text-2xl font-bold text-center bg-zinc-300	py-4 w-full'>{children}</div>;
 };


### PR DESCRIPTION
## 何が変わったのか
### ・チェックした県の人口構成データを取得＆表示＆削除する機能を実装
→グラフに表示する際に必要なデータをブラウザに表示して確認
→チェックした県を複数表示できるようにした
→一度選択したチェックボックスを再度押すと、その選択した県の人口構成データを削除するようにした

### ・タイトルのレスポンシブ対応
→モバイルサイズでUIを確認した際に、「都道府県別の総人口推移」のページタイトル文字がデカすぎた。そのため、640px以下の際に文字が小さくなるように変更
→都道府県すべてをブラウザに表示

## やっていないことorこれからやること
・グラフに表示する機能の実装
・ロジック面のコードを簡潔することや、コンポーネント分けなどのリファクタリング作業
## 現状のUI
### ・チェックした県の人口構成データを取得＆表示＆削除する機能のデモ

https://user-images.githubusercontent.com/103019604/199192781-12d21b1f-de02-4de1-b55e-6d03e53e9ad7.mov

### ・レスポンシブの画面UI

https://user-images.githubusercontent.com/103019604/199193296-f7b9daaf-673b-45c1-9bc6-cb3019e1d830.mov


