### PR TITLE
データをグラフに表示する機能実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react": "^18.0.24",
         "@types/react-dom": "^18.0.8",
         "axios": "^1.1.3",
-        "highcharts": "^10.2.1",
+        "highcharts": "^10.3.1",
         "highcharts-react-official": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -8361,9 +8361,9 @@
       }
     },
     "node_modules/highcharts": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.1.tgz",
-      "integrity": "sha512-4QwLQwWc0XdBHXc2Uy6IJisAUir+sgQIMyFqYZc3BD9iFSFUdllLkRyoed6y33aPb73LAMZE2qLB5SuLqFE/fg=="
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.3.1.tgz",
+      "integrity": "sha512-8UgVcLmgpiYwnsII0Ht76O+GRutfbrLslZFH3c53fXgl3aZ6NRB4mW5qsIyfsUExMny/n9JqYO/BFNejOKC6AA=="
     },
     "node_modules/highcharts-react-official": {
       "version": "3.1.0",
@@ -22770,9 +22770,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "highcharts": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.1.tgz",
-      "integrity": "sha512-4QwLQwWc0XdBHXc2Uy6IJisAUir+sgQIMyFqYZc3BD9iFSFUdllLkRyoed6y33aPb73LAMZE2qLB5SuLqFE/fg=="
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.3.1.tgz",
+      "integrity": "sha512-8UgVcLmgpiYwnsII0Ht76O+GRutfbrLslZFH3c53fXgl3aZ6NRB4mW5qsIyfsUExMny/n9JqYO/BFNejOKC6AA=="
     },
     "highcharts-react-official": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
     "axios": "^1.1.3",
-    "highcharts": "^10.2.1",
+    "highcharts": "^10.3.1",
     "highcharts-react-official": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/Pages/PrefPopulationChart.tsx
+++ b/src/Pages/PrefPopulationChart.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-misused-promises */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import React, { useEffect, useState } from 'react';
 import { usePopulationDataQuery } from '../components/Hooks/usePopulationDataQuery';
 import { usePrefDataQuery } from '../components/Hooks/usePrefDataQuery';
 import { Layout } from '../components/Layout/Layout';
+import { PopulationGraphContainer } from '../components/PopulationGraph/PopulationGraph';
 import { SectionTitle } from '../components/Text/SectionTitle';
 import { Title } from '../components/Text/Title';
 
@@ -59,12 +58,13 @@ export const PrefPopulationChart = () => {
     <Layout>
       <Title>都道府県別の総人口推移</Title>
 
-      <div className='border m-6 p-4 rounded-md shadow'>
+      <div className='border m-6 p-4 rounded-md shadow lg:max-w-[75%]'>
         <SectionTitle>都道府県</SectionTitle>
         <div className='w-full flex  flex-wrap p-8 gap-3'>
           {prefData?.result?.map((pref) => {
             return (
               <div key={pref.prefCode} className='flex gap-1'>
+                {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
                 <input type='checkbox' value={pref.prefCode} onChange={handleChange} className='focus:outline-none' />
                 <p>{pref.prefName}</p>
               </div>
@@ -73,35 +73,9 @@ export const PrefPopulationChart = () => {
         </div>
       </div>
 
-      <div>
-        <h2 className='text-center my-2'>人口構成</h2>
-        <div className='flex justify-center flex-wrap gap-2 p-2'>
-          {prefList?.map((pref: PopulationData, i: number) => {
-            return (
-              <div key={`${i}-${i}`}>
-                <div className='text-green-500'>{pref.prefCode}</div>
-                <div className='text-gray-600'>{pref.prefName}</div>
-                {pref?.yearData?.map((prefChild: number, index: number) => {
-                  return (
-                    <div key={`${i}-${index}`}>
-                      <div className='flex gap-2 mr-2'>
-                        <div className='text-red-500'>{prefChild}</div>
-                      </div>
-                    </div>
-                  );
-                })}
-                {pref?.valueData?.map((prefChild: number, index: number) => {
-                  return (
-                    <div key={`${i}-${index}`}>
-                      <div className='flex gap-2 mr-2'>
-                        <div className='text-blue-500'>{prefChild}</div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })}
+      <div className='flex justify-center'>
+        <div className='w-screen lg:max-w-[75%]'>
+          <PopulationGraphContainer prefList={prefList} />
         </div>
       </div>
     </Layout>

--- a/src/Pages/PrefPopulationChart.tsx
+++ b/src/Pages/PrefPopulationChart.tsx
@@ -58,7 +58,7 @@ export const PrefPopulationChart = () => {
     <Layout>
       <Title>都道府県別の総人口推移</Title>
 
-      <div className='border m-6 p-4 rounded-md shadow lg:max-w-[75%]'>
+      <div className='border m-6 p-4 rounded-md shadow 2xl:max-w-screen-2xl'>
         <SectionTitle>都道府県</SectionTitle>
         <div className='w-full flex  flex-wrap p-8 gap-3'>
           {prefData?.result?.map((pref) => {
@@ -74,7 +74,7 @@ export const PrefPopulationChart = () => {
       </div>
 
       <div className='flex justify-center'>
-        <div className='w-screen lg:max-w-[75%]'>
+        <div className='w-screen 2xl:max-w-screen-2xl'>
           <PopulationGraphContainer prefList={prefList} />
         </div>
       </div>

--- a/src/components/Hooks/usePrefDataQuery.tsx
+++ b/src/components/Hooks/usePrefDataQuery.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export const usePrefDataQuery = () => {
   const [prefData, setPrefData] = useState<{

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -6,8 +6,6 @@ type LayoutProps = {
 
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
-    <div className='flex flex-col justify-center items-center min-w-full gap-8  m-0 pb-10 bg-white  grow'>
-      {children}
-    </div>
+    <div className='flex flex-col justify-center items-center min-w-full gap-8  pb-10 bg-white  grow'>{children}</div>
   );
 };

--- a/src/components/PopulationGraph/PopulationGraph.tsx
+++ b/src/components/PopulationGraph/PopulationGraph.tsx
@@ -68,9 +68,5 @@ export const PopulationGraphContainer: React.FC<Props> = ({ prefList }) => {
 
     series: convertData(prefList),
   };
-  return (
-    <div>
-      <HighchartsReact highcharts={Highcharts} options={options} />
-    </div>
-  );
+  return <HighchartsReact highcharts={Highcharts} options={options} />;
 };

--- a/src/components/PopulationGraph/PopulationGraph.tsx
+++ b/src/components/PopulationGraph/PopulationGraph.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { PopulationData } from '../../Pages/PrefPopulationChart';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+export type Props = {
+  prefList: PopulationData[];
+};
+
+export const PopulationGraphContainer: React.FC<Props> = ({ prefList }) => {
+  //グラフのseriesのデータに変換
+  const convertData = (prefList: PopulationData[]) => {
+    const seriesData = prefList.map((pref) => {
+      return {
+        name: pref.prefName,
+        data: pref.valueData,
+      };
+    });
+    return seriesData;
+  };
+
+  const options = {
+    accessibility: {
+      enabled: false,
+    },
+    title: {
+      text: '都道府県別人口構成グラフ',
+      margin: 40,
+    },
+
+    yAxis: {
+      title: {
+        align: 'high',
+        rotation: '0',
+        text: '人口数',
+        textAlign: 'high',
+        y: -20,
+      },
+    },
+
+    xAxis: {
+      accessibility: {
+        rangeDescription: 'Range: 1960 to 2045',
+      },
+      title: {
+        text: '年度',
+        textAlign: 'high',
+        align: 'high',
+        x: 20,
+        y: -20,
+      },
+      categories: prefList[0]?.yearData,
+    },
+
+    legend: {
+      layout: 'vertical',
+      align: 'right',
+      verticalAlign: 'middle',
+      y: -80,
+    },
+
+    plotOptions: {
+      series: {
+        label: {
+          connectorAllowed: true,
+        },
+      },
+    },
+
+    series: convertData(prefList),
+  };
+  return (
+    <div>
+      <HighchartsReact highcharts={Highcharts} options={options} />
+    </div>
+  );
+};

--- a/src/components/Text/Title.tsx
+++ b/src/components/Text/Title.tsx
@@ -5,5 +5,7 @@ type TitleProps = {
 };
 
 export const Title: React.FC<TitleProps> = ({ children }) => {
-  return <div className='sm:text-4xl text-2xl font-bold text-center bg-zinc-300	py-4 w-full'>{children}</div>;
+  return (
+    <div className='sm:text-4xl text-2xl font-bold text-center bg-zinc-300 text-gray-600	py-4 w-full'>{children}</div>
+  );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## 何が変わったのか
### ・チェックした県の人口構成データをグラフに表示する機能を実装
→Highchartsというライブラリを使用して表示（rechartよりも渡すデータの扱いが容易なため）
→そのためのデータ変換の処理
→y軸に「人口数」、x軸に「年度」を表示(位置などのスタイル調整も）

### ・都道府県のチェックボックス一覧とグラフのスタイル調整
→画面幅が大きくなるにつれて、チェックボックスの一覧とグラフも大きくなっていた。（幅が2000px以上の場合）大きくなりすぎていて、逆に見づらいので、max-widthを指定して大きさの上限を設定
→都道府県すべてをブラウザに表示
## ライブラリの参考url
Highcharts使用の際に参考にしたページ
https://www.highcharts.com/demo/line-basic

Highchartsのスタイル調整する際に参考にしたページ
https://api.highcharts.com/highcharts/xAxis.title.rotation

## やっていないことorこれからやること
・ロジック面のコードを簡潔すること＆コンポーネント分けなどのリファクタリング作業

## 現状のUI
### ・チェックした県の人口構成データをグラフに表示＆削除する機能のデモ

https://user-images.githubusercontent.com/103019604/199394553-3000bc1e-0d4f-40a2-a58b-2812a2c8b7ea.mov

### ・モバイル時と画面幅が大きい時（幅2000px以上）のUI

https://user-images.githubusercontent.com/103019604/199394843-ccf361f2-2500-45af-9363-3d7a2557f4aa.mov

